### PR TITLE
Fixing travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,9 @@ env:
     - python=2.7  CONDA_PY=27
     - python=3.5  CONDA_PY=35
     - python=3.6  CONDA_PY=36
-  
+
+  global:
+    - MINICONDA_VERSION=4.4.10
+
 after_success:
   - bash -x devtools/travis-ci/after_success.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,6 @@ env:
     - python=2.7  CONDA_PY=27
     - python=3.5  CONDA_PY=35
     - python=3.6  CONDA_PY=36
-
-  global:
-    - MINICONDA_VERSION=4.4.10
-
+  
 after_success:
   - bash -x devtools/travis-ci/after_success.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ script:
   - source activate test
   # Add omnia channel for packages
   - conda config --add channels omnia
+  # Add conda-force channel for packages
+  - conda config --add channels conda-forge
 
   # Install package dependencies
   - conda install --yes --file devtools/travis-ci/requirements.txt
@@ -29,7 +31,7 @@ env:
   matrix:
     - python=2.7  CONDA_PY=27
     - python=3.5  CONDA_PY=35
-    - python=3.4  CONDA_PY=34
+    - python=3.6  CONDA_PY=36
 
 after_success:
   - bash -x devtools/travis-ci/after_success.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,5 +33,8 @@ env:
     - python=3.5  CONDA_PY=35
     - python=3.6  CONDA_PY=36
 
+  global:
+    - MINICONDA_VERSION=4.4.10
+
 after_success:
   - bash -x devtools/travis-ci/after_success.sh

--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -16,8 +16,8 @@ bash $MINICONDA -b -p $MINICONDA_HOME
 # Configure miniconda
 export PIP_ARGS="-U"
 export PATH=$MINICONDA_HOME/bin:$PATH
+# Use the latest miniconda starting from MINICONDA_VERSION
 conda update --yes conda
-conda install -c https://conda.anaconda.org/omnia --yes "conda-build<3.0.0" jinja2 anaconda-client pip
 
 # Restore original directory
 popd

--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -6,17 +6,10 @@ cd $HOME
 MINICONDA=Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh
 MINICONDA_HOME=$HOME/miniconda3
 MINICONDA_MD5=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
-wget -q https://repo.continuum.io/miniconda/$MINICONDA
-# Parse version out of file as fall back
-# Sed cuts out everything before the first digit, then traps the first digit and everything after
-MINICONDA_DL_VER=$(head $MINICONDA | grep VER | sed -n 's/[^0-9]*\([0-9.]*\)/\1/p')
-MINICONDA_FILE_VER="Miniconda3-$MINICONDA_DL_VER-Linux-x86_64.sh"
-MINICONDA_MD5_VER=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA_FILE_VER | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
+wget -q http://repo.continuum.io/miniconda/$MINICONDA
 if [[ $MINICONDA_MD5 != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then
-    if [[ $MINICONDA_MD5_VER != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then
-        echo "Miniconda MD5 mismatch"
-        exit 1
-    fi
+    echo "WARNING: Miniconda MD5 mismatch!"
+    exit 1
 fi
 bash $MINICONDA -b -p $MINICONDA_HOME
 

--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -6,10 +6,17 @@ cd $HOME
 MINICONDA=Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh
 MINICONDA_HOME=$HOME/miniconda3
 MINICONDA_MD5=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
-wget -q http://repo.continuum.io/miniconda/$MINICONDA
+wget -q https://repo.continuum.io/miniconda/$MINICONDA
+# Parse version out of file as fall back
+# Sed cuts out everything before the first digit, then traps the first digit and everything after
+MINICONDA_DL_VER=$(head $MINICONDA | grep VER | sed -n 's/[^0-9]*\([0-9.]*\)/\1/p')
+MINICONDA_FILE_VER="Miniconda3-$MINICONDA_DL_VER-Linux-x86_64.sh"
+MINICONDA_MD5_VER=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA_FILE_VER | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
 if [[ $MINICONDA_MD5 != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then
-    echo "WARNING: Miniconda MD5 mismatch!"
-    exit 1
+    if [[ $MINICONDA_MD5_VER != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then
+        echo "Miniconda MD5 mismatch"
+        exit 1
+    fi
 fi
 bash $MINICONDA -b -p $MINICONDA_HOME
 

--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -13,9 +13,11 @@ if [[ $MINICONDA_MD5 != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then
 fi
 bash $MINICONDA -b -p $MINICONDA_HOME
 
-export PATH=$HOME/miniconda3/bin:$PATH
-
 # Configure miniconda
 export PIP_ARGS="-U"
 export PATH=$MINICONDA_HOME/bin:$PATH
 conda update --yes conda
+conda install -c https://conda.anaconda.org/omnia --yes "conda-build<3.0.0" jinja2 anaconda-client pip
+
+# Restore original directory
+popd

--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -3,12 +3,12 @@ pushd .
 cd $HOME
 
 # Install Miniconda
-MINICONDA=Miniconda3-latest-Linux-x86_64.sh
+MINICONDA=Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh
 MINICONDA_HOME=$HOME/miniconda3
 MINICONDA_MD5=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
 wget -q http://repo.continuum.io/miniconda/$MINICONDA
 if [[ $MINICONDA_MD5 != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then
-    echo "Miniconda MD5 mismatch"
+    echo "WARNING: Miniconda MD5 mismatch!"
     exit 1
 fi
 bash $MINICONDA -b -p $MINICONDA_HOME


### PR DESCRIPTION
Travis builds were broken.

I have

* Updated python matrix to include only 2.7, 3.5 and 3.6
* Added conda-forge channel to the builds
* Adds a fix for the MD5 checksum point. Now locally updates to the latest version but ensures we start with a valid miniconda script.  
